### PR TITLE
Added a para

### DIFF
--- a/src/main/java/org/joda/time/base/package.html
+++ b/src/main/java/org/joda/time/base/package.html
@@ -24,6 +24,7 @@
 <p>
 Implementation package providing abstract and base time classes.
 </p>
+<p>This is a para</p>
 <p>
 Provides abstract implementations of the Readable* interfaces.
 The Abstract* classes hold no fields and have no final methods.


### PR DESCRIPTION
The Joda-Time project has been running for many years now, and the codebase is stable.
Java SE 8 contains a new date and time library that is the successor to Joda-Time.
As such Joda-Time is primarily in maintenance mode and few pull requests are likely to be merged.

**As a general rule, most enhancement PRs will now be rejected.**

To save wasted effort, it is recommended that an issue is raised first.
The issue should clearly indicate that a PR is intended, and request approval for the work.

If you still want to raise a PR, please delete this text!
